### PR TITLE
Ytmm export fixes

### DIFF
--- a/KaddaOK.AvaloniaApp.Windows/Program.cs
+++ b/KaddaOK.AvaloniaApp.Windows/Program.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Drawing;
-using System.Text;
-using System.Windows.Forms;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Svg.Skia;
+using System;
+using System.Globalization;
+using System.Threading;
 
 namespace KaddaOK.AvaloniaApp.Windows;
 
@@ -15,6 +14,11 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
+
+        CultureInfo culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+        culture.NumberFormat.NumberDecimalSeparator = "."; //Force use . for regions that use ,
+        Thread.CurrentThread.CurrentCulture = culture;
+
         try
         {
             BuildAvaloniaApp()

--- a/KaddaOK.AvaloniaApp/ViewModels/EditLinesViewModel.cs
+++ b/KaddaOK.AvaloniaApp/ViewModels/EditLinesViewModel.cs
@@ -597,6 +597,16 @@ namespace KaddaOK.AvaloniaApp.ViewModels
         }
 
         [RelayCommand]
+        private async Task DeleteLine(object? parameter)
+        {
+            if (parameter is LyricLine deleteThisLine)
+            {
+                AddUndoSnapshot();
+                CurrentProcess.ChosenLines!.Remove(deleteThisLine);
+            }
+        }
+
+        [RelayCommand]
         private async Task AddNewLine(object? parameter)
         {
             if (parameter is LyricLine addLineAfter)

--- a/KaddaOK.AvaloniaApp/ViewModels/ExportViewModel.cs
+++ b/KaddaOK.AvaloniaApp/ViewModels/ExportViewModel.cs
@@ -150,7 +150,11 @@ namespace KaddaOK.AvaloniaApp.ViewModels
                 if (file != null)
                 {
                     await using var stream = await file.OpenWriteAsync();
-                    using var streamWriter = new StreamWriter(stream)
+
+                    // UTF-16 LE BOM
+                    Encoding encoding = new UnicodeEncoding(false, true);
+
+                    using var streamWriter = new StreamWriter(stream, encoding)
                     {
                         AutoFlush = true
                     };
@@ -196,7 +200,10 @@ namespace KaddaOK.AvaloniaApp.ViewModels
                         }
 
                         var projectContents = RzProjectSerializer.Serialize(generatedProject);
-                        File.WriteAllText(projectPath, projectContents);
+
+                        using var writer = new StreamWriter(projectPath, false, encoding);
+                        await writer.WriteAsync(projectContents);
+
                         pathToLaunch = projectPath;
                     }
 

--- a/KaddaOK.AvaloniaApp/Views/EditLinesView.axaml
+++ b/KaddaOK.AvaloniaApp/Views/EditLinesView.axaml
@@ -167,7 +167,7 @@
                                         CornerRadius="3">
                                         <Grid
                                             Classes="lineStack"
-                                            ColumnDefinitions="20,36,*,36,25">
+                                            ColumnDefinitions="20,36,*,36,25,25">
                                             <Button
                                                 Classes="lineMergeButton"
                                                 Grid.Column="0"
@@ -207,6 +207,13 @@
                                                 Content="⏱"
                                                 ToolTip.Tip="Edit timing"
                                                 Command="{Binding $parent[views:EditLinesView].((vm:EditLinesViewModel)DataContext).EditLineCommand}"
+                                                CommandParameter="{Binding}" />
+											<Button
+                                                Classes="lineDeleteButton"
+                                                Grid.Column="5"
+                                                Content="🗑"
+                                                ToolTip.Tip="Delete line"
+                                                Command="{Binding $parent[views:EditLinesView].((vm:EditLinesViewModel)DataContext).DeleteLineCommand}"
                                                 CommandParameter="{Binding}" />
                                         </Grid>
                                     </Border>


### PR DESCRIPTION
Set the decimal separator to (.) to ensure accurate timing interpretation in ytmm, regardless of the user's regional settings. 

Incorrect:
![Incorrect](https://github.com/KaddaOK/KaddaOKTools/assets/100489639/c3073561-1347-4b5b-b614-7b39abd6b5af)

Correct:
![image](https://github.com/KaddaOK/KaddaOKTools/assets/100489639/e57e79fc-964c-4aa3-9cf2-2eb0fc1eaa20)

Updated ExportToRzlrc to use UTF-16 LE BOM encoding instead of the default encoding to ensure compatibility with ytmm, especially for handling cyrillic and other non-latin texts.