### PR TITLE
Bugs 2026 June

### DIFF
--- a/KaddaOK.AvaloniaApp.Tests/ViewModels/EditLinesViewModelTests.cs
+++ b/KaddaOK.AvaloniaApp.Tests/ViewModels/EditLinesViewModelTests.cs
@@ -71,6 +71,22 @@ namespace KaddaOK.AvaloniaApp.Tests.ViewModels
                     }
                 }
             }
+
+            [Fact]
+            public void ShouldNotCrashIfPreviousLineHasNoWords()
+            {
+                var currentProcess = GetNewCurrentProcess();
+                currentProcess.ChosenLines!.First().Words = new ObservableCollection<LyricWord>();
+
+                var viewModel = new EditLinesViewModel(currentProcess, new LineSplitter(), new WordMerger(), new MinMaxFloatWaveStreamSampler(), null!)
+                    { EditLinesView = new DummyEditLinesView() };
+
+                viewModel.MoveLineToPrevious(currentProcess.ChosenLines!.Skip(1).First());
+
+                Assert.Single(currentProcess.ChosenLines!);
+                var line = currentProcess.ChosenLines!.First();
+                Assert.Equal(4, line.Words.Count);
+            }
         }
 
         public static LyricLine MakeLinePerSeconds(int startSecond, string sentence)

--- a/KaddaOK.AvaloniaApp/Models/KaraokeProcess.cs
+++ b/KaddaOK.AvaloniaApp/Models/KaraokeProcess.cs
@@ -529,6 +529,7 @@ namespace KaddaOK.AvaloniaApp.Models
                 if (SetProperty(ref chosenLines, value))
                 {
                     NarrowingStepCompletenessChanged();
+                    CanExportFactorsChanged();
                 };
             }
         }

--- a/KaddaOK.AvaloniaApp/ViewModels/EditLinesViewModel.cs
+++ b/KaddaOK.AvaloniaApp/ViewModels/EditLinesViewModel.cs
@@ -475,8 +475,8 @@ namespace KaddaOK.AvaloniaApp.ViewModels
 
                 var previousLine = CurrentProcess!.ChosenLines![movingLineIndex - 1];
                 // add a space to the previous last word if it doesn't have one
-                var previousLastWord = previousLine.Words!.Last();
-                if (!previousLastWord.Text?.EndsWith(" ") ?? false)
+                var previousLastWord = previousLine.Words!.LastOrDefault();
+                if (previousLastWord != null && !(previousLastWord.Text?.EndsWith(" ") ?? false))
                 {
                     previousLastWord.Text += " ";
                 }

--- a/KaddaOK.AvaloniaApp/Views/EditLinesView.axaml
+++ b/KaddaOK.AvaloniaApp/Views/EditLinesView.axaml
@@ -70,6 +70,26 @@
             />
         </MenuFlyout>
         <MenuFlyout
+            x:Key="EmptyLineFlyout">
+            <MenuItem 
+				Header="Delete Line"
+                Command="{Binding $parent[views:EditLinesView].((vm:EditLinesViewModel)DataContext).DeleteEntireLineCommand}"
+                CommandParameter="{Binding}"
+				/>
+            <MenuItem
+                Header="Start New Page With This Line"
+                Command="{Binding $parent[views:EditLinesView].((vm:EditLinesViewModel)DataContext).StartNewPageWithThisLineCommand}"
+                CommandParameter="{Binding}" />
+            <MenuItem
+                Header="Move Line to Previous Page"
+                Command="{Binding $parent[views:EditLinesView].((vm:EditLinesViewModel)DataContext).MoveLineToPreviousPageCommand}"
+                CommandParameter="{Binding}" />
+            <MenuItem
+                Header="Move Line to Next Page"
+                Command="{Binding $parent[views:EditLinesView].((vm:EditLinesViewModel)DataContext).MoveLineToNextPageCommand}"
+                CommandParameter="{Binding}" />
+        </MenuFlyout>
+        <MenuFlyout
             x:Key="WordButtonFlyout"
             x:DataType="library:LyricWord">
             <MenuItem
@@ -251,7 +271,8 @@
                                                 BorderThickness="0,0,1,1"
                                                 Margin="13,3,0,0"
                                                 Padding="0,0,0,3"
-                                                CornerRadius="3">
+                                                CornerRadius="3"
+                                                ContextFlyout="{StaticResource EmptyLineFlyout}">
                                             <Classes.isCursor>
                                                 <MultiBinding Converter="{StaticResource ObjectEqualityBooleanConverter}">
                                                     <Binding Path="." />

--- a/KaddaOK.Library.Tests/KbpContentsGeneratorTests.cs
+++ b/KaddaOK.Library.Tests/KbpContentsGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -28,6 +29,98 @@ namespace KaddaOK.Library.Tests
             {
                 var result = KbpContentsGenerator.ColorTo3DigitHex(new SKColor(originalRed, (byte?)originalGreen ?? originalRed, (byte?)originalBlue ?? (byte?)originalGreen ?? originalRed));
                 Assert.Equal(expectedResult, result);
+            }
+        }
+
+        public class PageFromLyricLines
+        {
+            [Fact]
+            public void ShouldNotCrashWithEmptyLines()
+            {
+                var ser = new KbpSerializer();
+                var gen = new KbpContentsGenerator(ser);
+                var result = gen.PageFromLyricLines(new List<LyricLine>
+                {
+                    new LyricLine
+                    {
+                        Words = new ObservableCollection<LyricWord>()
+                    },
+                    new LyricLine
+                    {
+                        Words = new ObservableCollection<LyricWord>
+                        {
+                            new LyricWord
+                            {
+                                Text = "Test",
+                                StartSecond = 5, 
+                                EndSecond = 10
+                            }
+                        },
+                    },
+                    new LyricLine
+                    {
+                        Words = new ObservableCollection<LyricWord>()
+                    },
+                }.ToArray());
+                Assert.NotNull(result);
+                // it should actually still have 3 lines
+                Assert.Equal(3, result.Lines.Count);
+                var firstLine = result.Lines[0];
+                Assert.Empty(firstLine.Words);
+                var secondLine = result.Lines[1];
+                var singleWord = Assert.Single(secondLine.Words);
+                Assert.Equal("Test", singleWord.Text);
+                Assert.Equal(500, singleWord.StartTicks);
+                Assert.Equal(1000, singleWord.EndTicks);
+            }
+        }
+
+        public class ArrangeIntoPages
+        {
+            [Fact]
+            public void ShouldUseLinesPerPageIfNoPageBreaks()
+            {
+                var ser = new KbpSerializer();
+                var gen = new KbpContentsGenerator(ser);
+                var lines = Enumerable.Range(0, 10).Select(i => new LyricLine { Words = new ObservableCollection<LyricWord>
+                {
+                        new LyricWord { Text = $"Line {i}", StartSecond = i, EndSecond = i + 1 }
+                }}).ToArray();
+                var result = gen.ArrangeIntoPages(lines, 3);
+                Assert.Equal(4, result.Count); // 3 pages of 3 lines, and 1 page of 1 line
+                Assert.Equal("Line 0", result[0][0].Text);
+                Assert.Equal("Line 1", result[0][1].Text);
+                Assert.Equal("Line 2", result[0][2].Text);
+                Assert.Equal("Line 3", result[1][0].Text);
+                Assert.Equal("Line 4", result[1][1].Text);
+                Assert.Equal("Line 5", result[1][2].Text);
+                Assert.Equal("Line 6", result[2][0].Text);
+                Assert.Equal("Line 7", result[2][1].Text);
+                Assert.Equal("Line 8", result[2][2].Text);
+                Assert.Equal("Line 9", result[3][0].Text);
+            }
+
+            [Fact]
+            public void ShouldUsePageBreaksIfAnyHavePageIndexes()
+            {
+                var ser = new KbpSerializer();
+                var gen = new KbpContentsGenerator(ser);
+                var lines = Enumerable.Range(0, 10).Select(i => new LyricLine { Words = new ObservableCollection<LyricWord>
+                {
+                        new LyricWord { Text = $"Line {i}", StartSecond = i, EndSecond = i + 1 }
+                }, PageIndex = i >= 3 ? (int?)1 : 0 }).ToArray();
+                var result = gen.ArrangeIntoPages(lines, 3);
+                Assert.Equal(2, result.Count); // based on 3 lines per page, it should be 4 pages, but with a page index on line 3, it should be one page of 3 lines then 1 page of 7 lines
+                Assert.Equal("Line 0", result[0][0].Text);
+                Assert.Equal("Line 1", result[0][1].Text);
+                Assert.Equal("Line 2", result[0][2].Text);
+                Assert.Equal("Line 3", result[1][0].Text);
+                Assert.Equal("Line 4", result[1][1].Text);
+                Assert.Equal("Line 5", result[1][2].Text);
+                Assert.Equal("Line 6", result[1][3].Text);
+                Assert.Equal("Line 7", result[1][4].Text);
+                Assert.Equal("Line 8", result[1][5].Text);
+                Assert.Equal("Line 9", result[1][6].Text); 
             }
         }
     }

--- a/KaddaOK.Library/KbpContentsGenerator.cs
+++ b/KaddaOK.Library/KbpContentsGenerator.cs
@@ -261,7 +261,9 @@ Comments  Created with Karaoke Builder Studio
             {
                 if (i > 0)
                 {
-                    var startSecond = pages[i].Min(m => m.StartSecond);
+                    var startSecond = pages[i]
+                        .Where(i => i.EndSecond > 0) // ignore "Gap" lines
+                        .Min(m => m.StartSecond);
                     var previousEndSecond = pages[i - 1].Max(m => m.EndSecond);
                     if (previousEndSecond > startSecond)
                     {
@@ -272,7 +274,9 @@ Comments  Created with Karaoke Builder Studio
                 if (i < pages.Count - 1)
                 {
                     var endSecond = pages[i].Max(m => m.EndSecond);
-                    var nextStartSecond = pages[i + 1].Min(m => m.StartSecond);
+                    var nextStartSecond = pages[i + 1]
+                        .Where(i => i.EndSecond > 0) // ignore "Gap" lines
+                        .Min(m => m.StartSecond);
                     if (endSecond > nextStartSecond)
                     {
                         return false;
@@ -314,8 +318,20 @@ Comments  Created with Karaoke Builder Studio
             };
 
             // set some sane defaults, which we may have to mess with
-            kbpLine.DisplayStartTicks = Math.Max(kbpLine.Words.Min(w => w.StartTicks) - 300, 0);
-            kbpLine.DisplayEndTicks = Math.Max(kbpLine.Words.Max(w => w.EndTicks) + 50, 0);
+            if (kbpLine.Words != null && kbpLine.Words.Any())
+            {
+                kbpLine.DisplayStartTicks = Math.Max(kbpLine.Words.Min(w => w.StartTicks) - 300, 0);
+                kbpLine.DisplayEndTicks = Math.Max(kbpLine.Words.Max(w => w.EndTicks) + 50, 0);
+            }
+            else
+            {
+                // yep, this is actually a thing in KBS; it's "Gap", used to space the other lines on a page down, 
+                // and it does want the line to start and end at time 0 regardless of wherever it is on the page... 
+                // ¯\_(ツ)_/¯
+                kbpLine.DisplayStartTicks = 0;
+                kbpLine.DisplayEndTicks = 0;
+            }
+
 
             return kbpLine;
         }
@@ -383,7 +399,7 @@ Comments  Created with Karaoke Builder Studio
             return kbpPages;
         }
 
-        private List<LyricLine[]> ArrangeIntoPages(IEnumerable<LyricLine> processedResults, int linesPerPage)
+        public List<LyricLine[]> ArrangeIntoPages(IEnumerable<LyricLine> processedResults, int linesPerPage)
         {
             var pages = processedResults.Chunk(linesPerPage).ToList();
             if (processedResults.Any(p => p.PageIndex != null))

--- a/KaddaOK.Library/KbpSerializer.cs
+++ b/KaddaOK.Library/KbpSerializer.cs
@@ -78,7 +78,7 @@ namespace KaddaOK.Library
         {
             var page = new PageV2();
 
-            var pageLines = pageText.Split(Environment.NewLine).Select(s => s.Trim()).Where(h => !string.IsNullOrWhiteSpace(h) && !h.StartsWith("'")).ToList();
+            var pageLines = pageText.Split(Environment.NewLine).Select(s => s.Trim()).Where(h => !string.IsNullOrWhiteSpace(h)).ToList();
 
             var lineIndex = 0;
             // sanity check

--- a/KaddaOK.Library/KbpSerializer.cs
+++ b/KaddaOK.Library/KbpSerializer.cs
@@ -51,7 +51,7 @@ namespace KaddaOK.Library
                 pages.AddRange(kbpFile.Pages.Select(p => p.ToString()));
             }
             
-            return string.Join(PageBreak + Environment.NewLine, pages);
+            return string.Join(PageBreak + Environment.NewLine, pages) + PageBreak + Environment.NewLine;
         }
 
         private List<PageV2> ParsePages(List<string> pageTexts)

--- a/KaddaOK.Library/Kbs/Kbp.cs
+++ b/KaddaOK.Library/Kbs/Kbp.cs
@@ -220,9 +220,16 @@ namespace KaddaOK.Library.Kbs
         {
             var sb = new StringBuilder();
             sb.AppendLine($"{Alignment}/{GetStyleCode(StyleIndex, IsFixedText)}/{DisplayStartTicks}/{DisplayEndTicks}/{Across}/{Down}/{Rotation}");
-            foreach (var word in Words)
+            if (!Words.Any())
             {
-                sb.AppendLine(word.ToString());
+                sb.AppendLine("/              0/0/0");
+            }
+            else
+            {
+                foreach (var word in Words)
+                {
+                    sb.AppendLine(word.ToString());
+                }
             }
             
             return sb.ToString();

--- a/KaddaOK.Library/Kbs/Kbp.cs
+++ b/KaddaOK.Library/Kbs/Kbp.cs
@@ -53,18 +53,39 @@ namespace KaddaOK.Library.Kbs
         public override string ToString()
         {
             var sb = new StringBuilder();
+            sb.AppendLine("-----------------------------");
+            sb.AppendLine("KARAOKE BUILDER STUDIO");
+            sb.AppendLine("www.KaraokeBuilder.com");
+            sb.AppendLine();
+            sb.AppendLine("-----------------------------");
             sb.AppendLine("HEADERV2");
+            sb.AppendLine();
+            sb.AppendLine("'--- Template Information ---");
+            sb.AppendLine();
+            sb.AppendLine("'Palette Colours (0-15)");
             sb.AppendLine($"  {string.Join(",", PaletteColors.Select(s => s.ToString()))}");
-
+            sb.AppendLine();
+            sb.AppendLine("'Styles (00-19)");
+            sb.AppendLine("'  Number,Name");
+            sb.AppendLine("'  Colour: Text,Outline,Text Wipe,Outline Wipe");
+            sb.AppendLine("'  Font  : Name,Size,Style,Charset");
+            sb.AppendLine("'  Other : Outline*4,Shadow*2,Wiping,Uppercase");
+            sb.AppendLine();
             foreach (var style in Styles)
             {
                 sb.AppendLine(style.ToString());
+                sb.AppendLine();
             }
-
             sb.AppendLine("  StyleEnd");
+            sb.AppendLine();
+            sb.AppendLine("'Margins : L,R,T,Line Spacing");
             sb.AppendLine($"  {MarginLeft},{MarginRight},{MarginTop},{LineSpacing}");
+            sb.AppendLine();
+            sb.AppendLine("'Other: Border Colour,Detail Level");
             sb.AppendLine($"  {BorderColorPaletteIndex},{(int)Detail}");
-
+            sb.AppendLine();
+            sb.AppendLine("'--- Track Information ---");
+            sb.AppendLine();
             sb.AppendLine("Status    1"); // I still don't know what this means
             sb.AppendLine($"Title     {Title}");
             sb.AppendLine($"Artist    {Artist}");
@@ -72,6 +93,7 @@ namespace KaddaOK.Library.Kbs
             sb.AppendLine($"BuildFile {BuildFile}");
             sb.AppendLine($"Intro     {Intro}");
             sb.AppendLine($"Outro     {Outro}");
+            sb.AppendLine();
             if (!string.IsNullOrWhiteSpace(Comments))
             {
                 var commentLines = Comments.Split(Environment.NewLine);
@@ -85,7 +107,7 @@ namespace KaddaOK.Library.Kbs
                 }
                 sb.AppendLine($"Comments  {string.Join(Environment.NewLine, commentLines)}");
             }
-
+            sb.AppendLine();
             return sb.ToString();
         }
     }

--- a/KaddaOK.Library/Ytmm/RzlrcLyric.cs
+++ b/KaddaOK.Library/Ytmm/RzlrcLyric.cs
@@ -91,40 +91,40 @@ namespace KaddaOK.Library.Ytmm
         public uint clrOverlayShine { get; set; }
         
         [XmlAttribute]
-        public short iocs00 { get; set; }
+        public uint iocs00 { get; set; }
         
         [XmlAttribute]
-        public short iocs01 { get; set; }
+        public uint iocs01 { get; set; }
         
         [XmlAttribute]
-        public short iocs02 { get; set; }
+        public uint iocs02 { get; set; }
         
         [XmlAttribute]
-        public short iocs03 { get; set; }
+        public uint iocs03 { get; set; }
         
         [XmlAttribute]
-        public short iocs04 { get; set; }
+        public uint iocs04 { get; set; }
         
         [XmlAttribute]
-        public short iocs05 { get; set; }
+        public uint iocs05 { get; set; }
         
         [XmlAttribute]
-        public short iocs06 { get; set; }
+        public uint iocs06 { get; set; }
         
         [XmlAttribute]
-        public short iocs07 { get; set; }
+        public uint iocs07 { get; set; }
         
         [XmlAttribute]
-        public short iocs08 { get; set; }
+        public uint iocs08 { get; set; }
         
         [XmlAttribute]
-        public short iocs09 { get; set; }
+        public uint iocs09 { get; set; }
         
         [XmlAttribute]
-        public short clrOverlayGradient { get; set; }
+        public uint clrOverlayGradient { get; set; }
         
         [XmlAttribute]
-        public short clrOverlayHatch { get; set; }
+        public uint clrOverlayHatch { get; set; }
         
         [XmlAttribute]
         public short eAlignType { get; set; }


### PR DESCRIPTION
A bunch of bug fixes: 

- Some data types were too small for `.rzlrc` lyrics, causing occasional failures to open YTMM files.
- When you loaded back in a previous `.koktpj`, the Export tab did not become enabled.
- Other projects that use `.kbp` files were sensitive to the `'` comment blocks KBS normally inserts being omitted, so they've been added and should be much more compatible now. 
- Speaking of which, `'` is only a comment in the KBS header block; the page importer ignoring it just caused words that start with it (like `'cause` or `'til`) to disappear from the otherwise successfully imported page. (#15) 
- It's actually valid in `.kbp` to have an empty line with no syllables, that starts and ends at time 0 regardless of wherever it is in the song; that's how KBS's "Gap" button works. Users found a way to enter these into KOKT by putting just a `/` character in the new line dialog, but it would crash when trying to export (or using the move all to previous line button). 

New feature: 

- Added a right-click context menu on lines outside of syllables, mostly for the benefit of that last bug bullet.